### PR TITLE
Remove vertical direction from Swiper config

### DIFF
--- a/components/tiktok-viewer/tiktok-viewer.js
+++ b/components/tiktok-viewer/tiktok-viewer.js
@@ -96,7 +96,6 @@ export class TikTokViewer {
 
     initSwiper() {
         this.swiper = new Swiper('.tiktok-swiper', {
-            direction: 'vertical',
             slidesPerView: 1,
             spaceBetween: 0,
             // mousewheel: true,


### PR DESCRIPTION
The 'direction: vertical' option was removed from the Swiper initialization in TikTokViewer. This may revert the swiper to its default horizontal direction or rely on other configuration elsewhere.