### PR TITLE
Reduce preview image width in TikTokViewer

### DIFF
--- a/components/tiktok-viewer/tiktok-viewer.js
+++ b/components/tiktok-viewer/tiktok-viewer.js
@@ -53,7 +53,7 @@ export class TikTokViewer {
 
     renderSlide(item, index) {
         const urlImage = item.imagePath.replace('/blob/', '/refs/heads/').replace('https://github.com/', 'https://raw.githubusercontent.com/')
-        const previewImage = `https://images.weserv.nl/?url=${urlImage.replace('https://', '')}&w=800`
+        const previewImage = `https://images.weserv.nl/?url=${urlImage.replace('https://', '')}&w=400`
         return `
             <div class="swiper-slide model relative h-full">
                 <div class="w-full h-full flex items-center justify-center">


### PR DESCRIPTION
Changed the preview image width from 800 to 400 in the TikTokViewer component to optimize image loading and display.